### PR TITLE
:bug: fix build issue by managing dependency in buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   kotlin("jvm") version "1.6.21"
   // Upgrading to 0.4.1 Breaks the build
-  id("com.ryandens.javaagent-application") version "0.4.1"
+  id("com.ryandens.javaagent-application")
 }
 
 repositories {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    implementation("com.ryandens.javaagent-application:com.ryandens.javaagent-application.gradle.plugin:0.4.1")
+}


### PR DESCRIPTION
As you can see from [this build scan](https://scans.gradle.com/s/rllyvtkrc4ghk/dependencies?toggled=W1swXSxbMCwxXSxbMCwxLFsxNV1dLFsxXSxbMSwwXSxbMSwwLFsxXV0sWzEsMCxbMSwxNF1dLFsxLDAsWzEsMTQsMl1dXQ) the project can have the kotlin 1.6 dependency while the build can use kotlin 1.8+